### PR TITLE
fix: remove copy of entrypoint.sh which is no longer used

### DIFF
--- a/build/package/form3-toxies/Dockerfile
+++ b/build/package/form3-toxies/Dockerfile
@@ -12,7 +12,7 @@ FROM alpine
 
 ARG APPNAME
 WORKDIR /app
-COPY build/package/$APPNAME/entrypoint.sh /app/
+
 COPY --from=build-env /go/bin/$APPNAME /app/
 
 RUN ip -4 route list match 0/0 | awk '{print $3 "host.docker.internal"}' >> /etc/hosts


### PR DESCRIPTION
Removes reference in Dockerfile to `entrypoint.sh` which does not exist.