### PR TITLE
ci: add credentials and token permissions to fix release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,10 @@ jobs:
   publish:
     if: startsWith(github.ref, 'refs/tags')
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: write
     steps:
       - name: Checkout Code
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8 # v3.1.0


### PR DESCRIPTION
## Description
Release is failing due to the lacking of GitHub token and content permissions.
Added them to fix the release step.